### PR TITLE
Fix port and env variables in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ consumer secret needed to access Facebook's API.  Start the server with those
 variables set to the appropriate credentials.
 
 ```bash
-$ CLIENT_ID=__FACEBOOK_CLIENT_ID__ CLIENT_SECRET=__FACEBOOK_CLIENT_SECRET__ node server.js
+$ FACEBOOK_CLIENT_ID=__FACEBOOK_CLIENT_ID__ FACEBOOK_CLIENT_SECRET=__FACEBOOK_CLIENT_SECRET__ node server.js
 ```
 
 Open a web browser and navigate to [http://localhost:8080/](http://localhost:8080/)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,5 @@ variables set to the appropriate credentials.
 $ CLIENT_ID=__FACEBOOK_CLIENT_ID__ CLIENT_SECRET=__FACEBOOK_CLIENT_SECRET__ node server.js
 ```
 
-Open a web browser and navigate to [http://localhost:3000/](http://localhost:3000/)
+Open a web browser and navigate to [http://localhost:8080/](http://localhost:8080/)
 to see the example in action.
-
-


### PR DESCRIPTION
- both 8080 and 300 are widely used for testing, changed the README to match the code
- FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET are better env variables names than their variants without the FACEBOOK_ prefix because its likely a real-world app would have more login provides hence more client ids and client secrets. Therefore I changed the readme to match the env variables name in the code.